### PR TITLE
Add license info for external JS

### DIFF
--- a/heroicons.libraries.yml
+++ b/heroicons.libraries.yml
@@ -1,7 +1,12 @@
 alpine:
+  remote: https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js
   version: 3.x
   js:
     https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js: { type: external, minified: true }
+  license:
+    name: MIT
+    url: https://github.com/alpinejs/alpine/blob/master/LICENSE
+    gpl-compatible: true
 
 alpine_virtual:
   remote: https://cdn.jsdelivr.net/npm/@alpinejs/virtual@3.x.x/dist/cdn.min.js
@@ -10,6 +15,10 @@ alpine_virtual:
     https://cdn.jsdelivr.net/npm/@alpinejs/virtual@3.x.x/dist/cdn.min.js: { type: external, minified: true }
   dependencies:
     - heroicons/alpine
+  license:
+    name: MIT
+    url: https://github.com/alpinejs/alpine/blob/master/LICENSE
+    gpl-compatible: true
 
 headless_ui:
   remote: https://cdn.jsdelivr.net/npm/@headlessui/alpine@1.0.7/dist/headlessui.min.js
@@ -18,6 +27,10 @@ headless_ui:
     https://cdn.jsdelivr.net/npm/@headlessui/alpine@1.0.7/dist/headlessui.min.js: { type: external, minified: true }
   dependencies:
     - heroicons/alpine
+  license:
+    name: MIT
+    url: https://github.com/tailwindlabs/headlessui/blob/main/LICENSE
+    gpl-compatible: true
 
 combobox:
   css:


### PR DESCRIPTION
## Summary
- provide remote key for alpine library
- document upstream MIT licenses for external JS

## Testing
- `drush cr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2e63d584832890453dbcc02658c3