### PR TITLE
Fix sprite style mapping in heroicons template

### DIFF
--- a/templates/heroicons-sprite.html.twig
+++ b/templates/heroicons-sprite.html.twig
@@ -9,22 +9,17 @@
 #}
 <svg class="heroicons-sprite" style="position: absolute; width: 0; height: 0; pointer-events: none; visibility: hidden;">
   <defs>
-    {% for style in ['solid', 'outline'] %}
-      {% set size = style == 'outline' ? '24' : '16' %}
+    {% set style_map = {
+      'outline': {'size': '24', 'path_style': 'outline'},
+      'solid': {'size': '24', 'path_style': 'solid'},
+      'mini': {'size': '20', 'path_style': 'solid'},
+      'micro': {'size': '16', 'path_style': 'solid'}
+    } %}
+
+    {% for style_name, config in style_map %}
       {% for icon_name in sprite_icons %}
-        {% set icon_path = 'icons/' ~ size ~ '/' ~ style ~ '/' ~ icon_name ~ '.svg' %}
+        {% set icon_path = 'icons/' ~ config.size ~ '/' ~ config.path_style ~ '/' ~ icon_name ~ '.svg' %}
         {% if icon_exists(icon_path) %}
-          {{ include_icon(icon_path, 'hi-' ~ style ~ '-' ~ icon_name)|raw }}
-        {% endif %}
-      {% endfor %}
-    {% endfor %}
-    
-    {# Also include 20px and 24px solid for mini/micro styles #}
-    {% for size in ['20', '24'] %}
-      {% for icon_name in sprite_icons %}
-        {% set icon_path = 'icons/' ~ size ~ '/solid/' ~ icon_name ~ '.svg' %}
-        {% if icon_exists(icon_path) %}
-          {% set style_name = size == '20' ? 'mini' : (size == '24' ? 'solid24' : 'micro') %}
           {{ include_icon(icon_path, 'hi-' ~ style_name ~ '-' ~ icon_name)|raw }}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## Summary
- correct style ids for generated icon sprite so JS path lookups match

## Testing
- `pre-commit` *(fails: `pre-commit` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f8086bc8328af060e2570e1574d